### PR TITLE
walkmod changes

### DIFF
--- a/src/main/java/me/tomassetti/symbolsolver/JavaParserFacade.java
+++ b/src/main/java/me/tomassetti/symbolsolver/JavaParserFacade.java
@@ -17,13 +17,13 @@ import me.tomassetti.symbolsolver.model.typesolvers.JreTypeSolver;
 import me.tomassetti.symbolsolver.model.usages.*;
 import me.tomassetti.symbolsolver.model.javaparser.JavaParserFactory;
 import me.tomassetti.symbolsolver.model.javaparser.UnsolvedSymbolException;
-import me.tomassetti.symbolsolver.model.javaparser.contexts.MethodCallExprContext;
+
 
 import java.util.*;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collector;
+
 import java.util.stream.Collectors;
 
 /**
@@ -354,15 +354,7 @@ public class JavaParserFacade {
         }
     }
 
-    private SymbolReference<MethodDeclaration> solveMethod(MethodCallExpr methodCallExpr) {
-        List<TypeUsage> params = new ArrayList<>();
-        if (methodCallExpr.getArgs() != null) {
-            for (Expression param : methodCallExpr.getArgs()) {
-                params.add(getType(param));
-            }
-        }
-        return new MethodCallExprContext(methodCallExpr).solveMethod(methodCallExpr.getName(), params, typeSolver);
-    }
+    
 
     public TypeUsage convert(Type type, Node node) {
         return convert(type, JavaParserFactory.getContext(node));
@@ -388,21 +380,7 @@ public class JavaParserFacade {
         return methodUsage.get();
     }
 
-    private MethodUsage replaceParams(MethodUsage methodUsage, TypeUsage typeOfScope) {
-        logger.finest("ReplaceParams " + methodUsage);
-        logger.finest("ReplaceParams N params " + methodUsage.getParamTypes().size());
-        for (int i=0;i<methodUsage.getParamTypes().size();i++) {
-            TypeUsage typeUsage = methodUsage.getParamTypes().get(i);
-            TypeUsage replaced = replaceParams(typeUsage, typeOfScope);
-            logger.finest("ReplaceParams param type " + typeUsage);
-            if (replaced != typeUsage) {
-                logger.finest("ReplaceParams param -> " + replaced);
-                methodUsage = methodUsage.replaceParamType(i, replaced);
-            }
-        }
-        logger.finest("Final method usage "+methodUsage);
-        return methodUsage;
-    }
+    
 
     public static TypeUsage replaceParams(TypeUsage typeToReplace, TypeUsage typeOfScope) {
         if (typeToReplace.isTypeVariable()) {

--- a/src/main/java/me/tomassetti/symbolsolver/ProjectResolver.java
+++ b/src/main/java/me/tomassetti/symbolsolver/ProjectResolver.java
@@ -1,29 +1,29 @@
 package me.tomassetti.symbolsolver;
 
-import com.github.javaparser.JavaParser;
+
 import com.github.javaparser.ParseException;
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.ImportDeclaration;
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.PackageDeclaration;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.FieldDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.body.VariableDeclarator;
-import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.stmt.Statement;
-import me.tomassetti.symbolsolver.model.TypeSolver;
-import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;
-import me.tomassetti.symbolsolver.model.javaparser.UnsolvedSymbolException;
+
+
+
+
+
+
+
+
+
+
+
+
+
 import me.tomassetti.symbolsolver.model.typesolvers.CombinedTypeSolver;
 import me.tomassetti.symbolsolver.model.typesolvers.JavaParserTypeSolver;
 import me.tomassetti.symbolsolver.model.typesolvers.JreTypeSolver;
-import me.tomassetti.symbolsolver.model.usages.TypeUsage;
+
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+
+
 
 /**
  * Created by federico on 21/08/15.

--- a/src/main/java/me/tomassetti/symbolsolver/SourceFileInfoExtractor.java
+++ b/src/main/java/me/tomassetti/symbolsolver/SourceFileInfoExtractor.java
@@ -7,24 +7,24 @@ import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.FieldDeclaration;
+
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.stmt.Statement;
 import me.tomassetti.symbolsolver.model.TypeSolver;
 import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;
-import me.tomassetti.symbolsolver.model.typesolvers.CombinedTypeSolver;
-import me.tomassetti.symbolsolver.model.typesolvers.JavaParserTypeSolver;
-import me.tomassetti.symbolsolver.model.typesolvers.JreTypeSolver;
+
+
+
 import me.tomassetti.symbolsolver.model.usages.TypeUsage;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.io.PrintWriter;
-import java.util.HashMap;
-import java.util.Map;
+
+
+
 
 /**
  * It print information extracted from a source file. It is mainly intended as an example usage of JavaSymbolSolver.

--- a/src/main/java/me/tomassetti/symbolsolver/javaparser/Navigator.java
+++ b/src/main/java/me/tomassetti/symbolsolver/javaparser/Navigator.java
@@ -5,7 +5,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
-import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.stmt.SwitchStmt;
 

--- a/src/main/java/me/tomassetti/symbolsolver/model/Value.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/Value.java
@@ -3,7 +3,7 @@ package me.tomassetti.symbolsolver.model;
 import me.tomassetti.symbolsolver.model.declarations.ValueDeclaration;
 import me.tomassetti.symbolsolver.model.usages.TypeUsage;
 
-import java.lang.reflect.Type;
+
 
 /**
  * Created by federico on 04/08/15.

--- a/src/main/java/me/tomassetti/symbolsolver/model/declarations/ClassDeclaration.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/declarations/ClassDeclaration.java
@@ -50,7 +50,7 @@ public interface ClassDeclaration extends TypeDeclaration, TypeParametrized {
             ancestors.add(new TypeUsageOfTypeDeclaration(getSuperClass(typeSolver)));
             ancestors.addAll(getSuperClass(typeSolver).getAllAncestors(typeSolver));
         }
-        ancestors.addAll(getAllInterfaces(typeSolver).stream().map((i)->new TypeUsageOfTypeDeclaration(i)).collect(Collectors.toList()));
+        ancestors.addAll(getAllInterfaces(typeSolver).stream().map((i)->new TypeUsageOfTypeDeclaration(i)).collect(Collectors.<TypeUsageOfTypeDeclaration>toList()));
         return ancestors;
     }
 

--- a/src/main/java/me/tomassetti/symbolsolver/model/declarations/InterfaceDeclaration.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/declarations/InterfaceDeclaration.java
@@ -3,7 +3,7 @@ package me.tomassetti.symbolsolver.model.declarations;
 import me.tomassetti.symbolsolver.model.TypeSolver;
 
 import java.util.ArrayList;
-import java.util.Collection;
+
 import java.util.List;
 
 /**

--- a/src/main/java/me/tomassetti/symbolsolver/model/declarations/TypeParametrized.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/declarations/TypeParametrized.java
@@ -1,10 +1,10 @@
 package me.tomassetti.symbolsolver.model.declarations;
 
 import me.tomassetti.symbolsolver.model.TypeParameter;
-import me.tomassetti.symbolsolver.model.usages.TypeUsage;
+
 
 import java.util.List;
-import java.util.Optional;
+
 
 /**
  * @author Federico Tomassetti

--- a/src/main/java/me/tomassetti/symbolsolver/model/declarations/ValueDeclaration.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/declarations/ValueDeclaration.java
@@ -2,7 +2,7 @@ package me.tomassetti.symbolsolver.model.declarations;
 
 import me.tomassetti.symbolsolver.model.TypeSolver;
 import me.tomassetti.symbolsolver.model.usages.TypeUsage;
-import me.tomassetti.symbolsolver.model.usages.TypeUsageOfTypeDeclaration;
+
 
 /**
  * @author Federico Tomassetti

--- a/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/AbstractJavaParserContext.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/AbstractJavaParserContext.java
@@ -3,7 +3,7 @@ package me.tomassetti.symbolsolver.model.javaparser.contexts;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
-import com.github.javaparser.ast.stmt.SwitchStmt;
+
 import me.tomassetti.symbolsolver.model.*;
 import me.tomassetti.symbolsolver.model.declarations.ValueDeclaration;
 import me.tomassetti.symbolsolver.model.javaparser.JavaParserFactory;

--- a/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/CompilationUnitContext.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/CompilationUnitContext.java
@@ -13,7 +13,7 @@ import me.tomassetti.symbolsolver.model.javaparser.declarations.JavaParserInterf
 import me.tomassetti.symbolsolver.model.usages.TypeUsage;
 
 import java.util.List;
-import java.util.Optional;
+
 
 /**
  * Created by federico on 30/07/15.

--- a/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/ConstructorContext.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/ConstructorContext.java
@@ -1,7 +1,7 @@
 package me.tomassetti.symbolsolver.model.javaparser.contexts;
 
 import com.github.javaparser.ast.body.ConstructorDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
+
 import com.github.javaparser.ast.body.Parameter;
 import me.tomassetti.symbolsolver.model.SymbolDeclarator;
 import me.tomassetti.symbolsolver.model.SymbolReference;

--- a/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/EnumDeclarationContext.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/EnumDeclarationContext.java
@@ -13,7 +13,7 @@ import me.tomassetti.symbolsolver.model.usages.TypeUsage;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
+
 
 /**
  * @author Federico Tomassetti

--- a/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/FieldAccessContext.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/FieldAccessContext.java
@@ -2,10 +2,10 @@ package me.tomassetti.symbolsolver.model.javaparser.contexts;
 
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
-import com.github.javaparser.ast.expr.MethodCallExpr;
+
 import me.tomassetti.symbolsolver.JavaParserFacade;
 import me.tomassetti.symbolsolver.model.SymbolReference;
-import me.tomassetti.symbolsolver.model.SymbolSolver;
+
 import me.tomassetti.symbolsolver.model.TypeSolver;
 import me.tomassetti.symbolsolver.model.Value;
 import me.tomassetti.symbolsolver.model.declarations.MethodDeclaration;

--- a/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/ForStatementContext.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/ForStatementContext.java
@@ -5,7 +5,7 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ForStmt;
-import com.github.javaparser.ast.stmt.ForeachStmt;
+
 import me.tomassetti.symbolsolver.model.SymbolReference;
 import me.tomassetti.symbolsolver.model.TypeSolver;
 import me.tomassetti.symbolsolver.model.declarations.MethodDeclaration;

--- a/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/LambdaExprContext.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/LambdaExprContext.java
@@ -1,6 +1,6 @@
 package me.tomassetti.symbolsolver.model.javaparser.contexts;
 
-import com.github.javaparser.ast.Node;
+
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.LambdaExpr;

--- a/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/MethodCallExprContext.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/MethodCallExprContext.java
@@ -7,7 +7,7 @@ import me.tomassetti.symbolsolver.model.*;
 import me.tomassetti.symbolsolver.model.declarations.MethodDeclaration;
 import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;
 import me.tomassetti.symbolsolver.model.declarations.ValueDeclaration;
-import me.tomassetti.symbolsolver.model.javaparser.JavaParserFactory;
+
 import me.tomassetti.symbolsolver.model.javaparser.UnsolvedSymbolException;
 import me.tomassetti.symbolsolver.model.usages.MethodUsage;
 import me.tomassetti.symbolsolver.model.usages.TypeUsage;

--- a/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/MethodContext.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/MethodContext.java
@@ -1,6 +1,6 @@
 package me.tomassetti.symbolsolver.model.javaparser.contexts;
 
-import com.github.javaparser.ast.*;
+
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import me.tomassetti.symbolsolver.model.*;

--- a/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/StatementContext.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/javaparser/contexts/StatementContext.java
@@ -4,7 +4,7 @@ import com.github.javaparser.ast.expr.LambdaExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.IfStmt;
 import com.github.javaparser.ast.stmt.Statement;
-import com.github.javaparser.ast.stmt.SwitchStmt;
+
 import me.tomassetti.symbolsolver.model.*;
 import me.tomassetti.symbolsolver.model.declarations.MethodDeclaration;
 import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;

--- a/src/main/java/me/tomassetti/symbolsolver/model/javaparser/declarations/JavaParserEnumConstantDeclaration.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/javaparser/declarations/JavaParserEnumConstantDeclaration.java
@@ -2,7 +2,7 @@ package me.tomassetti.symbolsolver.model.javaparser.declarations;
 
 import com.github.javaparser.ast.body.EnumDeclaration;
 import me.tomassetti.symbolsolver.model.TypeSolver;
-import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;
+
 import me.tomassetti.symbolsolver.model.declarations.ValueDeclaration;
 import me.tomassetti.symbolsolver.model.usages.TypeUsage;
 import me.tomassetti.symbolsolver.model.usages.TypeUsageOfTypeDeclaration;

--- a/src/main/java/me/tomassetti/symbolsolver/model/javaparser/declarations/JavaParserFieldDeclaration.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/javaparser/declarations/JavaParserFieldDeclaration.java
@@ -3,10 +3,10 @@ package me.tomassetti.symbolsolver.model.javaparser.declarations;
 import com.github.javaparser.ast.body.EnumConstantDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import me.tomassetti.symbolsolver.JavaParserFacade;
-import me.tomassetti.symbolsolver.model.declarations.EnumDeclaration;
+
 import me.tomassetti.symbolsolver.model.declarations.FieldDeclaration;
 import me.tomassetti.symbolsolver.model.TypeSolver;
-import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;
+
 import me.tomassetti.symbolsolver.model.usages.TypeUsage;
 import me.tomassetti.symbolsolver.model.usages.TypeUsageOfTypeDeclaration;
 

--- a/src/main/java/me/tomassetti/symbolsolver/model/javaparser/declarations/JavaParserParameterDeclaration.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/javaparser/declarations/JavaParserParameterDeclaration.java
@@ -4,7 +4,7 @@ import com.github.javaparser.ast.body.Parameter;
 import me.tomassetti.symbolsolver.JavaParserFacade;
 import me.tomassetti.symbolsolver.model.TypeSolver;
 import me.tomassetti.symbolsolver.model.declarations.ParameterDeclaration;
-import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;
+
 import me.tomassetti.symbolsolver.model.usages.TypeUsage;
 
 /**

--- a/src/main/java/me/tomassetti/symbolsolver/model/javaparser/declarations/JavaParserSymbolDeclaration.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/javaparser/declarations/JavaParserSymbolDeclaration.java
@@ -11,11 +11,11 @@ import com.github.javaparser.ast.type.PrimitiveType;
 import me.tomassetti.symbolsolver.JavaParserFacade;
 import me.tomassetti.symbolsolver.model.*;
 import me.tomassetti.symbolsolver.model.declarations.ValueDeclaration;
-import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;
+
 import me.tomassetti.symbolsolver.model.javaparser.JavaParserFactory;
 import me.tomassetti.symbolsolver.model.usages.PrimitiveTypeUsage;
 import me.tomassetti.symbolsolver.model.usages.TypeUsage;
-import me.tomassetti.symbolsolver.model.usages.TypeUsageOfTypeDeclaration;
+
 
 /**
  * Created by federico on 28/07/15.

--- a/src/main/java/me/tomassetti/symbolsolver/model/javassist/JavassistFieldDeclaration.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/javassist/JavassistFieldDeclaration.java
@@ -3,7 +3,7 @@ package me.tomassetti.symbolsolver.model.javassist;
 import javassist.CtField;
 import javassist.NotFoundException;
 import me.tomassetti.symbolsolver.model.TypeSolver;
-import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;
+
 import me.tomassetti.symbolsolver.model.usages.TypeUsage;
 
 /**

--- a/src/main/java/me/tomassetti/symbolsolver/model/javassist/JavassistMethodDeclaration.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/javassist/JavassistMethodDeclaration.java
@@ -17,7 +17,7 @@ import me.tomassetti.symbolsolver.model.usages.TypeUsage;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collector;
+
 import java.util.stream.Collectors;
 
 /**

--- a/src/main/java/me/tomassetti/symbolsolver/model/javassist/JavassistParameterDeclaration.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/javassist/JavassistParameterDeclaration.java
@@ -3,9 +3,9 @@ package me.tomassetti.symbolsolver.model.javassist;
 import javassist.CtClass;
 import me.tomassetti.symbolsolver.model.TypeSolver;
 import me.tomassetti.symbolsolver.model.declarations.ParameterDeclaration;
-import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;
+
 import me.tomassetti.symbolsolver.model.usages.TypeUsage;
-import me.tomassetti.symbolsolver.model.usages.TypeUsageOfTypeDeclaration;
+
 
 /**
  * Created by federico on 02/08/15.

--- a/src/main/java/me/tomassetti/symbolsolver/model/javassist/contexts/JavassistClassContext.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/javassist/contexts/JavassistClassContext.java
@@ -1,7 +1,7 @@
 package me.tomassetti.symbolsolver.model.javassist.contexts;
 
 import javassist.CtClass;
-import javassist.CtMethod;
+
 import javassist.bytecode.BadBytecode;
 import javassist.bytecode.SignatureAttribute;
 import me.tomassetti.symbolsolver.model.Context;
@@ -11,7 +11,7 @@ import me.tomassetti.symbolsolver.model.declarations.MethodDeclaration;
 import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;
 import me.tomassetti.symbolsolver.model.declarations.ValueDeclaration;
 import me.tomassetti.symbolsolver.model.usages.TypeUsage;
-import sun.reflect.generics.tree.ClassSignature;
+
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/me/tomassetti/symbolsolver/model/reflection/ReflectionClassDeclaration.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/reflection/ReflectionClassDeclaration.java
@@ -1,7 +1,7 @@
 package me.tomassetti.symbolsolver.model.reflection;
 
 import com.github.javaparser.ast.Node;
-import me.tomassetti.symbolsolver.JavaParserFacade;
+
 import me.tomassetti.symbolsolver.model.*;
 import me.tomassetti.symbolsolver.model.declarations.*;
 import me.tomassetti.symbolsolver.model.javaparser.UnsolvedSymbolException;
@@ -11,7 +11,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
-import java.util.LinkedList;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -84,9 +84,7 @@ public class ReflectionClassDeclaration implements ClassDeclaration {
 
     @Override
     public TypeUsage getUsage(Node node) {
-        for (TypeParameter tp : this.getTypeParameters()){
-            throw new UnsupportedOperationException("Find parameters of "+this+" in "+node);
-        }
+        
         return new TypeUsageOfTypeDeclaration(this);
     }
 

--- a/src/main/java/me/tomassetti/symbolsolver/model/reflection/ReflectionFactory.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/reflection/ReflectionFactory.java
@@ -1,11 +1,11 @@
 package me.tomassetti.symbolsolver.model.reflection;
 
-import com.github.javaparser.ast.TypeParameter;
-import javassist.CtClass;
-import javassist.NotFoundException;
-import me.tomassetti.symbolsolver.model.javassist.JavassistClassDeclaration;
+
+
+
+
 import me.tomassetti.symbolsolver.model.usages.*;
-import sun.reflect.generics.reflectiveObjects.TypeVariableImpl;
+
 
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;

--- a/src/main/java/me/tomassetti/symbolsolver/model/reflection/ReflectionFieldDeclaration.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/reflection/ReflectionFieldDeclaration.java
@@ -2,7 +2,7 @@ package me.tomassetti.symbolsolver.model.reflection;
 
 import me.tomassetti.symbolsolver.model.declarations.FieldDeclaration;
 import me.tomassetti.symbolsolver.model.TypeSolver;
-import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;
+
 import me.tomassetti.symbolsolver.model.usages.TypeUsage;
 
 import java.lang.reflect.Field;

--- a/src/main/java/me/tomassetti/symbolsolver/model/reflection/ReflectionInterfaceDeclaration.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/reflection/ReflectionInterfaceDeclaration.java
@@ -1,7 +1,7 @@
 package me.tomassetti.symbolsolver.model.reflection;
 
 import com.github.javaparser.ast.Node;
-import me.tomassetti.symbolsolver.JavaParserFacade;
+
 import me.tomassetti.symbolsolver.model.*;
 import me.tomassetti.symbolsolver.model.declarations.*;
 import me.tomassetti.symbolsolver.model.javaparser.UnsolvedSymbolException;
@@ -61,9 +61,7 @@ public class ReflectionInterfaceDeclaration implements InterfaceDeclaration {
 
     @Override
     public TypeUsage getUsage(Node node) {
-        for (TypeParameter tp : this.getTypeParameters()){
-            throw new UnsupportedOperationException("Find parameters of "+this+" in "+node);
-        }
+        
         return new TypeUsageOfTypeDeclaration(this);
     }
 

--- a/src/main/java/me/tomassetti/symbolsolver/model/reflection/ReflectionMethodDeclaration.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/reflection/ReflectionMethodDeclaration.java
@@ -11,10 +11,10 @@ import me.tomassetti.symbolsolver.model.usages.MethodUsage;
 import me.tomassetti.symbolsolver.model.usages.TypeUsage;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Type;
+
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collector;
+
 import java.util.stream.Collectors;
 
 /**

--- a/src/main/java/me/tomassetti/symbolsolver/model/reflection/ReflectionParameterDeclaration.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/reflection/ReflectionParameterDeclaration.java
@@ -2,9 +2,9 @@ package me.tomassetti.symbolsolver.model.reflection;
 
 import me.tomassetti.symbolsolver.model.TypeSolver;
 import me.tomassetti.symbolsolver.model.declarations.ParameterDeclaration;
-import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;
+
 import me.tomassetti.symbolsolver.model.usages.TypeUsage;
-import me.tomassetti.symbolsolver.model.usages.TypeUsageOfTypeDeclaration;
+
 
 import java.lang.reflect.Type;
 

--- a/src/main/java/me/tomassetti/symbolsolver/model/reflection/ReflectionTypeParameter.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/reflection/ReflectionTypeParameter.java
@@ -7,7 +7,7 @@ import me.tomassetti.symbolsolver.model.TypeSolver;
 import java.lang.reflect.TypeVariable;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collector;
+
 import java.util.stream.Collectors;
 
 public class ReflectionTypeParameter implements TypeParameter {

--- a/src/main/java/me/tomassetti/symbolsolver/model/typesolvers/JavaParserTypeSolver.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/typesolvers/JavaParserTypeSolver.java
@@ -3,15 +3,15 @@ package me.tomassetti.symbolsolver.model.typesolvers;
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseException;
 import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+
 import me.tomassetti.symbolsolver.JavaParserFacade;
 import me.tomassetti.symbolsolver.javaparser.Navigator;
 import me.tomassetti.symbolsolver.model.SymbolReference;
 import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;
 import me.tomassetti.symbolsolver.model.TypeSolver;
-import me.tomassetti.symbolsolver.model.javaparser.JavaParserFactory;
-import me.tomassetti.symbolsolver.model.javaparser.UnsolvedSymbolException;
-import me.tomassetti.symbolsolver.model.javaparser.declarations.JavaParserClassDeclaration;
+
+
+
 
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/me/tomassetti/symbolsolver/model/typesolvers/JreTypeSolver.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/typesolvers/JreTypeSolver.java
@@ -3,7 +3,7 @@ package me.tomassetti.symbolsolver.model.typesolvers;
 import me.tomassetti.symbolsolver.model.SymbolReference;
 import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;
 import me.tomassetti.symbolsolver.model.TypeSolver;
-import me.tomassetti.symbolsolver.model.javaparser.UnsolvedSymbolException;
+
 import me.tomassetti.symbolsolver.model.reflection.ReflectionClassDeclaration;
 import me.tomassetti.symbolsolver.model.reflection.ReflectionInterfaceDeclaration;
 

--- a/src/main/java/me/tomassetti/symbolsolver/model/usages/MethodUsage.java
+++ b/src/main/java/me/tomassetti/symbolsolver/model/usages/MethodUsage.java
@@ -1,6 +1,6 @@
 package me.tomassetti.symbolsolver.model.usages;
 
-import me.tomassetti.symbolsolver.model.SymbolReference;
+
 import me.tomassetti.symbolsolver.model.TypeSolver;
 import me.tomassetti.symbolsolver.model.declarations.MethodDeclaration;
 import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;
@@ -105,10 +105,7 @@ public class MethodUsage {
             }
         }
         int i = 0;
-        for (TypeUsage param : typeToBeExamined.parameters()) {
-            typeToBeExamined = typeToBeExamined.replaceParam(i, replaceNameParam(name, newValue, typeToBeExamined.parameters().get(i)));
-            i++;
-        }
+        
         return typeToBeExamined;
     }
 }

--- a/walkmod.xml
+++ b/walkmod.xml
@@ -1,0 +1,25 @@
+<!DOCTYPE walkmod PUBLIC "-//WALKMOD//DTD"  "http://www.walkmod.com/dtd/walkmod-1.0.dtd" >
+<walkmod>
+	<plugins>
+		<plugin groupId="org.walkmod" artifactId="walkmod-maven-plugin"
+			version="[1.1.1,)" />
+		<plugin groupId="org.walkmod" artifactId="walkmod-dead-code-cleaner-plugin"
+			version="1.0.0" />
+	</plugins>
+
+	<conf-providers>
+		<conf-provider type="walkmod:commons:maven"></conf-provider>
+	</conf-providers>
+	<chain name="main-chain">
+		<reader path="src/main/java">
+		</reader>
+		<walker>
+			<transformations>
+				<transformation type="walkmod:commons:unused-declarations-cleaner" />
+			</transformations>
+		</walker>
+		<writer path="src/main/java"
+			type="org.walkmod:walkmod-javalang-plugin:string-writer">
+		</writer>
+	</chain>
+</walkmod>


### PR DESCRIPTION
Hi Federico,

With your code I have detected 3 bugs on my "compiler" side. Two of them has been solved easily and the last version of the compiler has been deployed to the Maven Central repository. The first two bugs were:

1) Multiple imports that import a simple class name (some by wildcard an another explicitly).
2) Access to inherited attributes whose type is a TypeParameter (T) from "this".

The third bug is related to the type inference mechanism introduced in Java 8 (https://docs.oracle.com/javase/tutorial/java/generics/genTypeInference.html), when for example if you have a class like this one:

    public class A { public static void processAList(List<A> stringList) {}}

And you apply this call: 
A.processAList(Collections.emptyList());

The compiler must infer that emptyList() returns a List<A>. However, if I rewrite the expression in Java 7 like this one:

A.processAList(Collections.<A>emptyList());

The compiler works. I have needed to apply this little change in me.tomassetti.symbolsolver.model.declarations.ClassDeclaration. Line: 53

I am going create an issue for it: https://github.com/rpau/javalang-compiler/issues/2

For another hand, I have detected 2 issues into the clean code plugin that can be improved. I am going to add it as an issue:
https://github.com/rpau/walkmod-dead-code-cleaner-plugin/issues/1