### PR TITLE
Add getWrappedNode() function to JavaParser___Declaration objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ hs_err_pid*
 .idea
 *.iml
 target
+
+# Generated javadoc
+javadoc

--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -393,4 +393,14 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration {
     protected TypeSolver typeSolver() {
         return typeSolver;
     }
+
+	/**
+	 * Returns the JavaParser node associated with this JavaParserClassDeclaration.
+	 *
+	 * @return A visitable JavaParser node wrapped by this object.
+	 */
+	public com.github.javaparser.ast.body.ClassOrInterfaceDeclaration getWrappedNode()
+	{
+		return wrappedNode;
+	}
 }

--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserEnumConstantDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserEnumConstantDeclaration.java
@@ -26,4 +26,14 @@ public class JavaParserEnumConstantDeclaration implements ValueDeclaration {
         return wrappedNode.getName();
     }
 
+	/**
+	 * Returns the JavaParser node associated with this JavaParserEnumConstantDeclaration.
+	 *
+	 * @return A visitable JavaParser node wrapped by this object.
+	 */
+	public com.github.javaparser.ast.body.EnumConstantDeclaration getWrappedNode()
+	{
+		return wrappedNode;
+	}
+
 }

--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -273,6 +273,16 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration implement
         return Collections.emptyList();
     }
 
+	/**
+	 * Returns the JavaParser node associated with this JavaParserEnumDeclaration.
+	 *
+	 * @return A visitable JavaParser node wrapped by this object.
+	 */
+	public com.github.javaparser.ast.body.EnumDeclaration getWrappedNode()
+	{
+		return wrappedNode;
+	}
+
     private class ValuesMethod implements MethodDeclaration {
 
         @Override

--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserFieldDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserFieldDeclaration.java
@@ -11,7 +11,7 @@ import me.tomassetti.symbolsolver.javaparsermodel.JavaParserFacade;
 public class JavaParserFieldDeclaration implements FieldDeclaration {
 
     private VariableDeclarator variableDeclarator;
-    private com.github.javaparser.ast.body.FieldDeclaration fieldDeclaration;
+    private com.github.javaparser.ast.body.FieldDeclaration wrappedNode;
     private EnumConstantDeclaration enumConstantDeclaration;
     private TypeSolver typeSolver;
 
@@ -21,7 +21,7 @@ public class JavaParserFieldDeclaration implements FieldDeclaration {
         if (!(variableDeclarator.getParentNode() instanceof com.github.javaparser.ast.body.FieldDeclaration)) {
             throw new IllegalStateException();
         }
-        this.fieldDeclaration = (com.github.javaparser.ast.body.FieldDeclaration) variableDeclarator.getParentNode();
+        this.wrappedNode = (com.github.javaparser.ast.body.FieldDeclaration) variableDeclarator.getParentNode();
     }
 
     public JavaParserFieldDeclaration(EnumConstantDeclaration enumConstantDeclaration) {
@@ -34,7 +34,7 @@ public class JavaParserFieldDeclaration implements FieldDeclaration {
             com.github.javaparser.ast.body.EnumDeclaration enumDeclaration = (com.github.javaparser.ast.body.EnumDeclaration) enumConstantDeclaration.getParentNode();
             return new ReferenceTypeUsageImpl(new JavaParserEnumDeclaration(enumDeclaration, typeSolver), typeSolver);
         } else {
-            return JavaParserFacade.get(typeSolver).convert(fieldDeclaration.getType(), fieldDeclaration);
+            return JavaParserFacade.get(typeSolver).convert(wrappedNode.getType(), wrappedNode);
         }
     }
 
@@ -52,5 +52,14 @@ public class JavaParserFieldDeclaration implements FieldDeclaration {
         return true;
     }
 
+	/**
+	 * Returns the JavaParser node associated with this JavaParserFieldDeclaration.
+	 *
+	 * @return A visitable JavaParser node wrapped by this object.
+	 */
+	public com.github.javaparser.ast.body.FieldDeclaration getWrappedNode()
+	{
+		return wrappedNode;
+	}
 
 }

--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -327,4 +327,14 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration impl
     protected TypeSolver typeSolver() {
         return typeSolver;
     }
+
+	/**
+	 * Returns the JavaParser node associated with this JavaParserInterfaceDeclaration.
+	 *
+	 * @return A visitable JavaParser node wrapped by this object.
+	 */
+	public ClassOrInterfaceDeclaration getWrappedNode()
+	{
+		return wrappedNode;
+	}
 }

--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration.java
@@ -218,4 +218,13 @@ public class JavaParserMethodDeclaration implements MethodDeclaration {
         throw new UnsupportedOperationException();
     }
 
+	/**
+	 * Returns the JavaParser node associated with this JavaParserMethodDeclaration.
+	 *
+	 * @return A visitable JavaParser node wrapped by this object.
+	 */
+	public com.github.javaparser.ast.body.MethodDeclaration getWrappedNode()
+	{
+		return wrappedNode;
+	}
 }

--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserParameterDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserParameterDeclaration.java
@@ -45,4 +45,14 @@ public class JavaParserParameterDeclaration implements ParameterDeclaration {
     public TypeUsage getType() {
         return JavaParserFacade.get(typeSolver).convert(wrappedNode.getType(), wrappedNode);
     }
+
+	/**
+	 * Returns the JavaParser node associated with this JavaParserParameterDeclaration.
+	 *
+	 * @return A visitable JavaParser node wrapped by this object.
+	 */
+	public Parameter getWrappedNode()
+	{
+		return wrappedNode;
+	}
 }

--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserSymbolDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserSymbolDeclaration.java
@@ -141,4 +141,14 @@ public class JavaParserSymbolDeclaration implements ValueDeclaration {
     public TypeUsage getTypeUsage(TypeSolver typeSolver) {
         return JavaParserFacade.get(typeSolver).getType(wrappedNode);
     }*/
+
+	/**
+	 * Returns the JavaParser node associated with this JavaParserSymbolDeclaration.
+	 *
+	 * @return A visitable JavaParser node wrapped by this object.
+	 */
+	public Node getWrappedNode()
+	{
+		return wrappedNode;
+	}
 }

--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserTypeParameter.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserTypeParameter.java
@@ -158,4 +158,14 @@ public class JavaParserTypeParameter extends AbstractTypeDeclaration implements 
     protected TypeSolver typeSolver() {
         return typeSolver;
     }
+
+	/**
+	 * Returns the JavaParser node associated with this JavaParserTypeParameter.
+	 *
+	 * @return A visitable JavaParser node wrapped by this object.
+	 */
+	public com.github.javaparser.ast.TypeParameter getWrappedNode()
+	{
+		return wrappedNode;
+	}
 }

--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserTypeVariableDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserTypeVariableDeclaration.java
@@ -150,4 +150,14 @@ public class JavaParserTypeVariableDeclaration extends AbstractTypeDeclaration {
     public me.tomassetti.symbolsolver.model.resolution.TypeParameter asTypeParameter() {
         return new JavaParserTypeParameter(this.wrappedNode, typeSolver);
     }
+
+	/**
+	 * Returns the JavaParser node associated with this JavaParserTypeVariableDeclaration.
+	 *
+	 * @return A visitable JavaParser node wrapped by this object.
+	 */
+	public TypeParameter getWrappedNode()
+	{
+		return wrappedNode;
+	}
 }


### PR DESCRIPTION
Also changed member ```fieldDeclaration``` in JavaParserFieldDeclaration.java to ```wrappedNode``` for consistency. This fixes something for issue #6. 