### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/JavaParserFactory.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/JavaParserFactory.java
@@ -19,6 +19,9 @@ import me.tomassetti.symbolsolver.javaparsermodel.declarators.VariableSymbolDecl
 
 public class JavaParserFactory {
 
+    private JavaParserFactory() {
+    }
+
     public static Context getContext(Node node, TypeSolver typeSolver) {
         if (node == null) {
             return null;

--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javassistmodel/JavassistFactory.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javassistmodel/JavassistFactory.java
@@ -11,6 +11,9 @@ import me.tomassetti.symbolsolver.model.resolution.TypeSolver;
 
 public class JavassistFactory {
 
+    private JavassistFactory() {
+    }
+
     public static TypeUsage typeUsageFor(CtClass ctClazz, TypeSolver typeSolver) {
         try {
             if (ctClazz.isArray()) {

--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/reflectionmodel/ReflectionFactory.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/reflectionmodel/ReflectionFactory.java
@@ -6,6 +6,9 @@ import me.tomassetti.symbolsolver.model.typesystem.*;
 import java.lang.reflect.*;
 
 public class ReflectionFactory {
+    private ReflectionFactory() {
+    }
+
     public static TypeUsage typeUsageFor(Class<?> clazz, TypeSolver typeSolver) {
         if (clazz.isArray()) {
             return new ArrayTypeUsage(typeUsageFor(clazz.getComponentType(), typeSolver));

--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/reflectionmodel/ReflectionMethodResolutionLogic.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/reflectionmodel/ReflectionMethodResolutionLogic.java
@@ -19,6 +19,9 @@ import java.util.stream.Collectors;
 
 class ReflectionMethodResolutionLogic {
 
+    private ReflectionMethodResolutionLogic() {
+    }
+
     static Optional<MethodUsage> solveMethodAsUsage(String name, List<TypeUsage> parameterTypes, TypeSolver typeSolver,
                                                     Context invokationContext, List<TypeUsage> typeParameterValues,
                                                     TypeParametrized typeParametrized, Class clazz) {

--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/resolution/MethodResolutionLogic.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/resolution/MethodResolutionLogic.java
@@ -13,6 +13,9 @@ import java.util.stream.Collectors;
 
 public class MethodResolutionLogic {
 
+    private MethodResolutionLogic() {
+    }
+
     private static List<TypeUsage> groupVariadicParamValues(List<TypeUsage> paramTypes, int startVariadic, TypeUsage variadicType) {
         List<TypeUsage> res = new ArrayList<>(paramTypes.subList(0, startVariadic));
         List<TypeUsage> variadicValues = paramTypes.subList(startVariadic, paramTypes.size());

--- a/java-symbol-solver-examples/src/main/java/me/tomassetti/examples/PrintExpressionType.java
+++ b/java-symbol-solver-examples/src/main/java/me/tomassetti/examples/PrintExpressionType.java
@@ -20,6 +20,8 @@ import java.io.FileNotFoundException;
 public class PrintExpressionType {
 
 
+    private PrintExpressionType() {
+    }
 
     static class TypeCalculatorVisitor extends VoidVisitorAdapter<JavaParserFacade> {
         @Override

--- a/java-symbol-solver-logic/src/main/java/me/tomassetti/symbolsolver/logic/FunctionalInterfaceLogic.java
+++ b/java-symbol-solver-logic/src/main/java/me/tomassetti/symbolsolver/logic/FunctionalInterfaceLogic.java
@@ -9,6 +9,9 @@ import java.util.stream.Collectors;
 
 public class FunctionalInterfaceLogic {
 
+    private FunctionalInterfaceLogic() {
+    }
+
     public static Optional<MethodUsage> getFunctionalMethod(TypeUsage type) {
         if (type.isReferenceType() && type.asReferenceTypeUsage().getTypeDeclaration().isInterface()) {
             //We need to find all abstract methods

--- a/java-symbol-solver-logic/src/main/java/me/tomassetti/symbolsolver/logic/GenericTypeInferenceLogic.java
+++ b/java-symbol-solver-logic/src/main/java/me/tomassetti/symbolsolver/logic/GenericTypeInferenceLogic.java
@@ -10,6 +10,9 @@ import java.util.Map;
 
 public class GenericTypeInferenceLogic {
 
+    private GenericTypeInferenceLogic() {
+    }
+
     public static Map<String, TypeUsage> inferGenericTypes(List<Tuple2<TypeUsage, TypeUsage>> formalActualTypePairs) {
         Map<String, TypeUsage> map = new HashMap<>();
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.