### PR TITLE
[squid:S2259] Null pointers should not be dereferenced

### DIFF
--- a/java-symbol-solver-core/src/test/resources/javaparser_src/proper_source/com/github/javaparser/ast/comments/CommentsParser.java
+++ b/java-symbol-solver-core/src/test/resources/javaparser_src/proper_source/com/github/javaparser/ast/comments/CommentsParser.java
@@ -95,12 +95,14 @@ public class CommentsParser {
                     break;
                 case IN_LINE_COMMENT:
                     if (c=='\n' || c=='\r'){
-                        currentLineComment.setContent(currentContent.toString());
+                        currentLineComment.setContent(currentContent == null ? "" : currentContent.toString());
                         currentLineComment.setEndLine(currLine);
                         currentLineComment.setEndColumn(currCol);
                         comments.addComment(currentLineComment);
                         state = State.CODE;
                     } else {
+                        if (currentContent == null)
+                            currentContent = new StringBuffer();
                         currentContent.append(c);
                     }
                     break;
@@ -126,6 +128,8 @@ public class CommentsParser {
                         }
                         state = State.CODE;
                     } else {
+                        if (currentContent == null)
+                            currentContent = new StringBuffer();
                         currentContent.append(c=='\r'?'\n':c);
                     }
                     break;
@@ -159,7 +163,7 @@ public class CommentsParser {
         }
 
         if (state==State.IN_LINE_COMMENT){
-            currentLineComment.setContent(currentContent.toString());
+            currentLineComment.setContent(currentContent == null ? "" : currentContent.toString());
             currentLineComment.setEndLine(currLine);
             currentLineComment.setEndColumn(currCol);
             comments.addComment(currentLineComment);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2259 - “Null pointers should not be dereferenced”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2259

Please let me know if you have any questions.
Ayman Abdelghany.