### PR TITLE
[squid:S1149] Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/java-symbol-solver-core/src/test/resources/javaparser_src/generated/com/github/javaparser/ParseException.java
+++ b/java-symbol-solver-core/src/test/resources/javaparser_src/generated/com/github/javaparser/ParseException.java
@@ -101,7 +101,7 @@ public class ParseException extends Exception {
                            int[][] expectedTokenSequences,
                            String[] tokenImage) {
     String eol = System.getProperty("line.separator", "\n");
-    StringBuffer expected = new StringBuffer();
+    StringBuilder expected = new StringBuilder();
     int maxSize = 0;
     for (int i = 0; i < expectedTokenSequences.length; i++) {
       if (maxSize < expectedTokenSequences[i].length) {
@@ -151,7 +151,7 @@ public class ParseException extends Exception {
    * string literal.
    */
   static String add_escapes(String str) {
-      StringBuffer retval = new StringBuffer();
+      StringBuilder retval = new StringBuilder();
       char ch;
       for (int i = 0; i < str.length(); i++) {
         switch (str.charAt(i))

--- a/java-symbol-solver-core/src/test/resources/javaparser_src/generated/com/github/javaparser/TokenMgrError.java
+++ b/java-symbol-solver-core/src/test/resources/javaparser_src/generated/com/github/javaparser/TokenMgrError.java
@@ -60,7 +60,7 @@ public class TokenMgrError extends Error
    * equivalents in the given string
    */
   protected static final String addEscapes(String str) {
-    StringBuffer retval = new StringBuffer();
+    StringBuilder retval = new StringBuilder();
     char ch;
     for (int i = 0; i < str.length(); i++) {
       switch (str.charAt(i))

--- a/java-symbol-solver-core/src/test/resources/javaparser_src/proper_source/com/github/javaparser/ast/comments/CommentsParser.java
+++ b/java-symbol-solver-core/src/test/resources/javaparser_src/proper_source/com/github/javaparser/ast/comments/CommentsParser.java
@@ -56,7 +56,7 @@ public class CommentsParser {
         State state = State.CODE;
         LineComment currentLineComment = null;
         BlockComment currentBlockComment = null;
-        StringBuffer currentContent = null;
+        StringBuilder currentContent = null;
 
         int currLine = 1;
         int currCol  = 1;
@@ -78,13 +78,13 @@ public class CommentsParser {
                         currentLineComment.setBeginLine(currLine);
                         currentLineComment.setBeginColumn(currCol - 1);
                         state = State.IN_LINE_COMMENT;
-                        currentContent = new StringBuffer();
+                        currentContent = new StringBuilder();
                     } else if (prevTwoChars.peekLast().equals('/') && c == '*') {
                         currentBlockComment = new BlockComment();
                         currentBlockComment.setBeginLine(currLine);
                         currentBlockComment.setBeginColumn(currCol - 1);
                         state = State.IN_BLOCK_COMMENT;
-                        currentContent = new StringBuffer();
+                        currentContent = new StringBuilder();
                     } else if (c == '"') {
                         state = State.IN_STRING;
                     } else if (c == '\'') {

--- a/java-symbol-solver-model/src/main/java/me/tomassetti/symbolsolver/model/typesystem/ReferenceTypeUsage.java
+++ b/java-symbol-solver-model/src/main/java/me/tomassetti/symbolsolver/model/typesystem/ReferenceTypeUsage.java
@@ -233,7 +233,7 @@ public abstract class ReferenceTypeUsage implements TypeUsage {
 
     @Override
     public String describe() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (hasName()) {
             sb.append(typeDeclaration.getQualifiedName());
         } else {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.
Ayman Abdelghany.