### PR TITLE
[squid:S2864] "entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -252,8 +252,8 @@ public class JavaParserFacade {
                             TypeUsage formalType = functionalMethod.get().returnType();
                             formalActualTypePairs.add(new Tuple2<>(formalType, actualType));
                             Map<String, TypeUsage> inferredTypes = GenericTypeInferenceLogic.inferGenericTypes(formalActualTypePairs);
-                            for (String typeName : inferredTypes.keySet()) {
-                                result = result.replaceParam(typeName, inferredTypes.get(typeName));
+                            for (Map.Entry<String, TypeUsage> entry : inferredTypes.entrySet()) {
+                                result = result.replaceParam(entry.getKey(), entry.getValue());
                             }
                         } else {
                             throw new UnsupportedOperationException();

--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -79,8 +79,8 @@ public class MethodCallExprContext extends AbstractJavaParserContext<MethodCallE
             TypeUsage actualType = actualParamTypes.get(i);
             matchTypeParameters(expectedType, actualType, matchedTypeParameters);
         }
-        for (String tp : matchedTypeParameters.keySet()) {
-            methodUsage = methodUsage.replaceNameParam(tp, matchedTypeParameters.get(tp));
+        for (Map.Entry<String, TypeUsage> entry : matchedTypeParameters.entrySet()) {
+            methodUsage = methodUsage.replaceNameParam(entry.getKey(), entry.getValue());
         }
         return methodUsage;
     }

--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration.java
@@ -85,8 +85,8 @@ public class JavaParserMethodDeclaration implements MethodDeclaration {
             determineTypeParameters(determinedTypeParameters, formalParamType, actualParamType, typeSolver);
         }
 
-        for (String determinedParam : determinedTypeParameters.keySet()) {
-            returnType = returnType.replaceParam(determinedParam, determinedTypeParameters.get(determinedParam));
+        for (Map.Entry<String, TypeUsage> entry : determinedTypeParameters.entrySet()) {
+            returnType = returnType.replaceParam(entry.getKey(), entry.getValue());
         }
 
         return new MethodUsage(new JavaParserMethodDeclaration(wrappedNode, typeSolver), params, returnType);

--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
@@ -115,11 +115,11 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration impl
                 i++;
             }
             Map<String, TypeUsage> map = GenericTypeInferenceLogic.inferGenericTypes(formalActualTypePairs);
-            for (String key : map.keySet()) {
-                if (map.get(key) == null) {
+            for (Map.Entry<String, TypeUsage> entry : map.entrySet()) {
+                if (entry.getValue() == null) {
                     throw new IllegalArgumentException();
                 }
-                methodUsage = methodUsage.replaceNameParam(key, map.get(key));
+                methodUsage = methodUsage.replaceNameParam(entry.getKey(), entry.getValue());
             }
             return Optional.of(methodUsage);
         } else {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864

Please let me know if you have any questions.
Ayman Abdelghany.