### PR TITLE
Stackoverflow fix

### DIFF
--- a/java-symbol-solver-core/pom.xml
+++ b/java-symbol-solver-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>me.tomassetti</groupId>
     <artifactId>java-symbol-solver-parent</artifactId>
-    <version>0.2</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -59,12 +59,12 @@
       <dependency>
           <groupId>me.tomassetti</groupId>
           <artifactId>java-symbol-solver-model</artifactId>
-          <version>0.2</version>
+          <version>0.3-SNAPSHOT</version>
       </dependency>
       <dependency>
           <groupId>me.tomassetti</groupId>
           <artifactId>java-symbol-solver-logic</artifactId>
-          <version>0.2</version>
+          <version>0.3-SNAPSHOT</version>
       </dependency>
       <dependency>
           <groupId>com.javaslang</groupId>

--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
@@ -69,6 +69,8 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration {
             ReferenceTypeUsageImpl superClass = getSuperClass();
             ancestors.add(superClass);
             ancestors.addAll(getSuperClass().getAllAncestors());
+            ReferenceTypeUsageImpl object = new ReferenceTypeUsageImpl(new ReflectionClassDeclaration(Object.class, typeSolver), typeSolver);
+            ancestors.add(object);
         }
         ancestors.addAll(getAllInterfaces().stream().map((i) -> new ReferenceTypeUsageImpl(i, typeSolver)).collect(Collectors.<ReferenceTypeUsageImpl>toList()));
         for (int i = 0; i < ancestors.size(); i++) {
@@ -78,8 +80,6 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration {
                 i--;
             }
         }
-        ReferenceTypeUsageImpl object = new ReferenceTypeUsageImpl(new ReflectionClassDeclaration(Object.class, typeSolver), typeSolver);
-        ancestors.add(object);
         return ancestors;
     }
 
@@ -252,7 +252,6 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration {
             fields.add(new ReflectionFieldDeclaration(field, typeSolver));
         }
         for (ReferenceTypeUsage ancestor : getAllAncestors()) {
-            // TODO code in getField is rather complicated. Can this really be this simple?
             fields.addAll(ancestor.getTypeDeclaration().getAllFields());
         }
         return fields;

--- a/java-symbol-solver-core/src/test/java/me/tomassetti/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
+++ b/java-symbol-solver-core/src/test/java/me/tomassetti/symbolsolver/reflectionmodel/ReflectionClassDeclarationTest.java
@@ -1,11 +1,9 @@
 package me.tomassetti.symbolsolver.reflectionmodel;
 
 import com.google.common.collect.ImmutableSet;
-import me.tomassetti.symbolsolver.model.declarations.ClassDeclaration;
-import me.tomassetti.symbolsolver.model.declarations.FieldDeclaration;
-import me.tomassetti.symbolsolver.model.declarations.MethodDeclaration;
-import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;
+import me.tomassetti.symbolsolver.model.declarations.*;
 import me.tomassetti.symbolsolver.model.resolution.TypeSolver;
+import me.tomassetti.symbolsolver.model.typesystem.ReferenceTypeUsage;
 import me.tomassetti.symbolsolver.resolution.typesolvers.JreTypeSolver;
 import org.junit.Test;
 
@@ -199,4 +197,11 @@ public class ReflectionClassDeclarationTest {
     // getDeclaredMethods
     // getAllMethods
 
+    @Test
+    public void testGetAllFields() {
+        TypeSolver typeResolver = new JreTypeSolver();
+        ClassDeclaration arraylist = new ReflectionClassDeclaration(ArrayList.class, typeResolver);
+        assertEquals(ImmutableSet.of("modCount", "serialVersionUID", "MAX_ARRAY_SIZE", "size", "elementData", "EMPTY_ELEMENTDATA", "DEFAULTCAPACITY_EMPTY_ELEMENTDATA", "DEFAULT_CAPACITY"),
+                arraylist.getAllFields().stream().map(Declaration::getName).collect(Collectors.toSet()));
+    }
 }

--- a/java-symbol-solver-examples/pom.xml
+++ b/java-symbol-solver-examples/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>me.tomassetti</groupId>
     <artifactId>java-symbol-solver-parent</artifactId>
-    <version>0.2</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -59,7 +59,7 @@
      <dependency>
           <groupId>me.tomassetti</groupId>
           <artifactId>java-symbol-solver-core</artifactId>
-          <version>0.2</version>
+          <version>0.3-SNAPSHOT</version>
      </dependency>
   </dependencies>
   <build>

--- a/java-symbol-solver-logic/pom.xml
+++ b/java-symbol-solver-logic/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>me.tomassetti</groupId>
     <artifactId>java-symbol-solver-parent</artifactId>
-    <version>0.2</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -59,7 +59,7 @@
       <dependency>
           <groupId>me.tomassetti</groupId>
           <artifactId>java-symbol-solver-model</artifactId>
-          <version>0.2-SNAPSHOT</version>
+          <version>0.3-SNAPSHOT</version>
       </dependency>
       <dependency>
           <groupId>com.javaslang</groupId>

--- a/java-symbol-solver-logic/src/main/java/me/tomassetti/symbolsolver/logic/AbstractClassDeclaration.java
+++ b/java-symbol-solver-logic/src/main/java/me/tomassetti/symbolsolver/logic/AbstractClassDeclaration.java
@@ -26,6 +26,7 @@ public abstract class AbstractClassDeclaration extends AbstractTypeDeclaration i
         if (superClass != null) {
             superclasses.add(superClass);
             superclasses.addAll(superClass.getAllAncestors());
+            superclasses.add(object());
         }
         for (int i = 0; i < superclasses.size(); i++) {
             if (superclasses.get(i).getQualifiedName().equals(Object.class.getCanonicalName())) {
@@ -33,7 +34,6 @@ public abstract class AbstractClassDeclaration extends AbstractTypeDeclaration i
                 i--;
             }
         }
-        superclasses.add(object());
         return superclasses.stream().filter((s) -> s.getTypeDeclaration().isClass()).collect(Collectors.toList());
     }
 

--- a/java-symbol-solver-model/pom.xml
+++ b/java-symbol-solver-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>me.tomassetti</groupId>
     <artifactId>java-symbol-solver-parent</artifactId>
-    <version>0.2</version>
+    <version>0.3-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <groupId>me.tomassetti</groupId>
   <artifactId>java-symbol-solver-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.2</version>
+  <version>0.3-SNAPSHOT</version>
   <name>java-symbol-solver-parent</name>
   <url>https://github.com/ftomassetti/java-symbol-solver</url>
   <description>A Symbol Solver for Java, built on top of JavaParser</description>


### PR DESCRIPTION
Getting all fields always went into a stack overflow, because getting all superclasses or ancestor would loop. It would keep adding "Object" as the ancestor of anything, including Object, then asking for all ancestors, meaning Object, which contained Object again, thereby looping.