### PR TITLE
Expand LambdaExprContext to solve more lambda parameter types

### DIFF
--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/javaparsermodel/declarations/JavaParserMethodDeclaration.java
@@ -1,7 +1,10 @@
 package me.tomassetti.symbolsolver.javaparsermodel.declarations;
 
+import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ModifierSet;
+
 import me.tomassetti.symbolsolver.model.declarations.MethodDeclaration;
 import me.tomassetti.symbolsolver.model.declarations.ParameterDeclaration;
 import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;
@@ -134,12 +137,13 @@ public class JavaParserMethodDeclaration implements MethodDeclaration {
 
     @Override
     public boolean isAbstract() {
-        throw new UnsupportedOperationException();
+        return (wrappedNode.getBody() == null);
     }
 
     @Override
     public boolean isPrivate() {
-        throw new UnsupportedOperationException();
+        AccessSpecifier accessSpecifier = ModifierSet.getAccessSpecifier(wrappedNode.getModifiers());
+        return (accessSpecifier == AccessSpecifier.PRIVATE);
     }
 
     private Optional<TypeUsage> typeParamByName(String name, TypeSolver typeSolver, Context context) {

--- a/java-symbol-solver-core/src/test/java/me/tomassetti/symbolsolver/resolution/javaparser/contexts/LambdaExprContextTest.java
+++ b/java-symbol-solver-core/src/test/java/me/tomassetti/symbolsolver/resolution/javaparser/contexts/LambdaExprContextTest.java
@@ -1,0 +1,98 @@
+package me.tomassetti.symbolsolver.resolution.javaparser.contexts;
+
+import com.github.javaparser.ParseException;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.LambdaExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+
+import me.tomassetti.symbolsolver.javaparser.Navigator;
+import me.tomassetti.symbolsolver.javaparsermodel.contexts.LambdaExprContext;
+import me.tomassetti.symbolsolver.model.resolution.Context;
+import me.tomassetti.symbolsolver.model.resolution.TypeSolver;
+import me.tomassetti.symbolsolver.model.resolution.Value;
+import me.tomassetti.symbolsolver.resolution.*;
+import me.tomassetti.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import me.tomassetti.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
+import me.tomassetti.symbolsolver.resolution.typesolvers.JreTypeSolver;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Federico Tomassetti
+ */
+public class LambdaExprContextTest extends AbstractTest {
+
+    private TypeSolver typeSolver;
+
+    @Before
+    public void setup() {
+        typeSolver = new JreTypeSolver();
+    }
+
+    @Test
+    public void solveParameterOfLambdaInMethodCallExpr() throws ParseException {
+        CompilationUnit cu = parseSample("Lambda");
+
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Agenda");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "lambdaMap");
+        ReturnStmt returnStmt = Navigator.findReturnStmt(method);
+        MethodCallExpr methodCallExpr = (MethodCallExpr)returnStmt.getExpr();
+        LambdaExpr lambdaExpr = (LambdaExpr)methodCallExpr.getArgs().get(0);
+        
+        Context context = new LambdaExprContext(lambdaExpr, typeSolver);
+        
+        Optional<Value> ref = context.solveSymbolAsValue("p", typeSolver);
+        assertTrue(ref.isPresent());
+        assertEquals("? super java.lang.String", ref.get().getUsage().describe());
+    }
+
+    @Test
+    public void solveParameterOfLambdaInFieldDecl() throws ParseException {
+        CompilationUnit cu = parseSample("Lambda");
+
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Agenda");
+        VariableDeclarator field = Navigator.demandField(clazz, "functional");
+        LambdaExpr lambdaExpr = (LambdaExpr)field.getInit();
+        
+        File src = new File("src/test/resources");
+        CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
+        combinedTypeSolver.add(new JreTypeSolver());
+        combinedTypeSolver.add(new JavaParserTypeSolver(src));
+        
+        Context context = new LambdaExprContext(lambdaExpr, combinedTypeSolver);
+        
+        Optional<Value> ref = context.solveSymbolAsValue("p", typeSolver);
+        assertTrue(ref.isPresent());
+        assertEquals("java.lang.String", ref.get().getUsage().describe());
+    }
+    
+    @Test
+    public void solveParameterOfLambdaInVarDecl() throws ParseException {
+        CompilationUnit cu = parseSample("Lambda");
+
+        com.github.javaparser.ast.body.ClassOrInterfaceDeclaration clazz = Navigator.demandClass(cu, "Agenda");
+        MethodDeclaration method = Navigator.demandMethod(clazz, "testFunctionalVar");
+        VariableDeclarator varDecl = Navigator.demandVariableDeclaration(method, "a");
+        LambdaExpr lambdaExpr = (LambdaExpr)varDecl.getInit();
+                
+        File src = new File("src/test/resources");
+        CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
+        combinedTypeSolver.add(new JreTypeSolver());
+        combinedTypeSolver.add(new JavaParserTypeSolver(src));
+        
+        Context context = new LambdaExprContext(lambdaExpr, combinedTypeSolver);
+        
+        Optional<Value> ref = context.solveSymbolAsValue("p", typeSolver);
+        assertTrue(ref.isPresent());
+        assertEquals("java.lang.String", ref.get().getUsage().describe());
+    }
+}

--- a/java-symbol-solver-core/src/test/java/me/tomassetti/symbolsolver/resolution/javaparser/contexts/LambdaExprContextTest.java
+++ b/java-symbol-solver-core/src/test/java/me/tomassetti/symbolsolver/resolution/javaparser/contexts/LambdaExprContextTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * @author Federico Tomassetti
+ * @author Malte Langkabel
  */
 public class LambdaExprContextTest extends AbstractTest {
 

--- a/java-symbol-solver-core/src/test/resources/Lambda.java.txt
+++ b/java-symbol-solver-core/src/test/resources/Lambda.java.txt
@@ -1,11 +1,22 @@
 import java.util.List;
 
+@FunctionalInterface
+public interface Lambda {
+	String process(String value);
+}
+
 public class Agenda {
+	
+	Lambda functional = p -> p.toLowerCase();
 
     private List<String> persons;
 
     public void lambdaMap(String personName) {
         return persons.stream().map(p -> p.toLowerCase());
+    }
+
+    public void testFunctionalVar() {
+    	Lambda a = p -> p.toLowerCase();
     }
 
 }


### PR DESCRIPTION
added implementation for contexts other than method calls and implemented tests for newly supported cases.