### PR TITLE
Fixed comparing compatible types for raw types

### DIFF
--- a/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/model/typesystem/ReferenceTypeUsageImpl.java
+++ b/java-symbol-solver-core/src/main/java/me/tomassetti/symbolsolver/model/typesystem/ReferenceTypeUsageImpl.java
@@ -5,6 +5,7 @@ import me.tomassetti.symbolsolver.model.declarations.TypeDeclaration;
 import me.tomassetti.symbolsolver.model.invokations.MethodUsage;
 import me.tomassetti.symbolsolver.model.resolution.TypeParameter;
 import me.tomassetti.symbolsolver.model.resolution.TypeSolver;
+import me.tomassetti.symbolsolver.reflectionmodel.ReflectionClassDeclaration;
 import me.tomassetti.symbolsolver.javaparsermodel.LambdaArgumentTypeUsagePlaceholder;
 import me.tomassetti.symbolsolver.javaparsermodel.declarations.JavaParserTypeVariableDeclaration;
 
@@ -34,6 +35,12 @@ public class ReferenceTypeUsageImpl extends ReferenceTypeUsage {
 
     public ReferenceTypeUsageImpl(TypeDeclaration typeDeclaration, List<TypeUsage> typeParameters, TypeSolver typeSolver) {
         super(typeDeclaration, typeParameters, typeSolver);
+        if (!typeDeclaration.getTypeParameters().isEmpty() && typeParameters.isEmpty()) {
+            // add object type usages as type parameters if this is a raw type
+            for (int i = 0; i < typeDeclaration.getTypeParameters().size(); i++) {
+                super.typeParameters.add(new ReferenceTypeUsageImpl(new ReflectionClassDeclaration(Object.class, typeSolver), typeSolver));
+            }
+        }
     }
 
     @Override

--- a/java-symbol-solver-core/src/test/resources/javaparser_expected_output/com_github_javaparser_ast_comments_CommentsParser.txt
+++ b/java-symbol-solver-core/src/test/resources/javaparser_expected_output/com_github_javaparser_ast_comments_CommentsParser.txt
@@ -12,7 +12,7 @@
   Line 51) CommentsCollection comments = new CommentsCollection() ==> com.github.javaparser.ast.comments.CommentsCollection
   Line 51) new CommentsCollection() ==> com.github.javaparser.ast.comments.CommentsCollection
   Line 52) int r ==> int
-  Line 54) Deque prevTwoChars = new LinkedList<Character>(Arrays.asList('z', 'z')) ==> java.util.Deque
+  Line 54) Deque prevTwoChars = new LinkedList<Character>(Arrays.asList('z', 'z')) ==> java.util.Deque<java.lang.Object>
   Line 54) new LinkedList<Character>(Arrays.asList('z', 'z')) ==> java.util.LinkedList<java.lang.Character>
   Line 56) State state = State.CODE ==> com.github.javaparser.ast.comments.CommentsParser.State
   Line 56) State.CODE ==> com.github.javaparser.ast.comments.CommentsParser.State

--- a/java-symbol-solver-model/src/main/java/me/tomassetti/symbolsolver/model/typesystem/ReferenceTypeUsage.java
+++ b/java-symbol-solver-model/src/main/java/me/tomassetti/symbolsolver/model/typesystem/ReferenceTypeUsage.java
@@ -299,6 +299,8 @@ public abstract class ReferenceTypeUsage implements TypeUsage {
                             // ok
                         } else if (thisParamAsWildcard.isExtends() && thisParamAsWildcard.getBoundedType().isAssignableBy(otherParam)) {
                             // ok
+                        } else if (otherParam.describe().equals("java.lang.Object")) {
+                            // ok
                         } else {
                             return false;
                         }


### PR DESCRIPTION
Until now we had an issue solving a method that requires a generic type as argument but is provided a raw type (see issue #68).
The implementation on this branch works fine but we lose the information that the type provided as argument is actually a raw type. Therefore I'm not sure if we should use this implementation or find a different solution. 
I think that the "different solution" would involve implementing edge cases in every method that can fail because of raw types (e.g. `ReferenceTypeUsage.compareConsideringTypeParameters(...)`, `GenericTypeInferenceLogic.consider(...)`, ...). 

So I don't know if this would be worth it. So I would propose to use the method implemented here and store the fact wether or not a ReferenceTypeUsage uses a raw type as a boolean field. 

@ftomassetti: What do you think?